### PR TITLE
Add `CSON.register()` which then allows to call `require('file.cson')`

### DIFF
--- a/lib/cson.coffee
+++ b/lib/cson.coffee
@@ -71,3 +71,13 @@ module.exports =
 	# Turn an object into JSON/CSON Synchronously
 	stringifySync: (obj) ->
 		JSON.stringify obj
+
+	# Register extension to require
+	# "require('file.cson')" will return parsed file (synchronous)
+	register: () ->
+		if require.extensions
+			require.extensions['.cson'] = (module, filename) ->
+				module.exports = @parseFileSync filename
+		else if require.registerExtension
+			require.registerExtension '.cson', (content) ->
+				@parseSync content.toString()


### PR DESCRIPTION
Usage:

``` javascript
var CSON = require('cson')
CSON.register() // Registers ".cson" extension
var object = require('./object.cson')
```

This is very similar to call `CSON.parseFileSync`, except that `require()` handles cache and it's sometimes convenient to rely on a generic API, so that you can change the backend whenever you would need it later.
