### PR TITLE
The parser returns an `Error` object whenever there is a function injected inside a CSON data

### DIFF
--- a/lib/cson.coffee
+++ b/lib/cson.coffee
@@ -2,7 +2,7 @@
 coffee = require('coffee-script')
 js2coffee = require('js2coffee')
 fs = require('fs')
-
+_ = require 'underscore'
 
 # Define
 CSON = 
@@ -68,9 +68,14 @@ CSON =
 		catch err
 			try
 				json = coffee.compile("return (#{src})")
-				result = eval json
-				result = JSON.stringify result
-				result = JSON.parse result
+				jsonObj = eval json
+
+				objToJson = JSON.stringify jsonObj
+
+				result = JSON.parse objToJson
+
+				unless _.isEqual result, jsonObj
+					throw new Error "The inputed CSON file has been determined as evil."
 			catch err
 				result = err
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
 	},
 	"dependencies": {
 		"coffee-script": "1.3.x",
-		"js2coffee": "0.1.x"
+		"js2coffee": "0.1.x",
+		"underscore": "1.3.x"
 	},
 	"devDependencies": {
 		"mocha": "1.0.x"

--- a/test/currupt.test.coffee
+++ b/test/currupt.test.coffee
@@ -1,0 +1,21 @@
+# Requires
+assert = require('assert')
+fs = require('fs')
+CSON = require(__dirname+'/../lib/cson.coffee')
+srcCsonPath = __dirname+'/src/currupt.cson'
+
+
+# =====================================
+# Tests
+
+# Test sync
+describe 'corrupt cson', ->
+	it 'shall not corrupt the system', (done) ->
+		# Read expectations
+
+		# Parse CSON File
+		obj = CSON.parseFileSync(srcCsonPath)
+		assert.ok(obj instanceof Error)
+
+		# Tests done
+		done()

--- a/test/src/currupt.cson
+++ b/test/src/currupt.cson
@@ -1,0 +1,4 @@
+{
+	evil: ->
+		console.log 'I am supposedly really evil.'
+}


### PR DESCRIPTION
So now, there is no longer any risks that a function gets passed in through the CSON data. Unless you guys wanted that, it's a nice fix.

This fixes issue #11.
