### PR TITLE
Added the ability to `require` a cson file.

### DIFF
--- a/src/lib/cson.coffee
+++ b/src/lib/cson.coffee
@@ -4,6 +4,7 @@ js2coffee = require('js2coffee')
 fsUtil = require('fs')
 pathUtil = require('path')
 
+
 # Awesomeness
 wait = (delay,fn) -> setTimeout(fn,delay)
 
@@ -176,6 +177,11 @@ CSON =
 		# Return
 		result
 
+if require.extensions
+	require.extensions['.cson'] = (module, filename) ->
+		csonDat = JSON.stringify CSON.parseFileSync filename
+		csonDat = "module.exports = #{csonDat}"
+		module._compile csonDat, filename
 
 # Export
 module.exports = CSON

--- a/src/test/everything.test.coffee
+++ b/src/test/everything.test.coffee
@@ -1,3 +1,4 @@
 # Tests
 require(__dirname+'/async.test')
 require(__dirname+'/sync.test')
+require(__dirname+'/require.test')

--- a/src/test/require.test.coffee
+++ b/src/test/require.test.coffee
@@ -1,0 +1,10 @@
+joe = require 'joe'
+CSON = require "#{__dirname}/../lib/cson"
+assert = require 'assert'
+
+joe.describe 'require', (describe, it) ->
+  it 'should load using require', (done) ->
+    csonDat = JSON.stringify require '../../test/src/1.cson'
+    jsonDat = JSON.stringify require '../../test/out-expected/1.json'
+    assert.equal csonDat, jsonDat
+    done()


### PR DESCRIPTION
CoffeeScript is able to `require` `.coffee` files. The `require` function itself is perfectly capable of `require`ing `.json` files. How about we do the same for `.cson` files? This pull request does exactly that.
