### PR TITLE
Fix #8: Allow standard input

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "ambi": "^2.2.0",
     "coffee-script": "~1.7.1",
+    "docopt": "^0.4.0",
     "extract-opts": "~2.2.0",
     "js2coffee": "~0.3.0",
     "requirefresh": "~1.1.2"

--- a/src/bin/cson2json.coffee
+++ b/src/bin/cson2json.coffee
@@ -1,19 +1,21 @@
 # Requires
-fs = require('fs')
+util = require('util')
 path = require('path')
-CSON = require(path.join __dirname, '..', 'lib', 'cson')
-argv = process.argv
 
-# Check arguments
-unless argv.length is 3
-	console.log('usage: cson2json filePath')
-	process.exit(1)
+CLI = require(path.join __dirname, '..', 'lib', 'cli')
 
-# Extract
-filePath = argv[2]
 
-# Convert
-result = JSON.stringify CSON.parseFileSync(filePath)
-console.log(result)
+# Declarations
+__PROGRAM_NAME = 'cson2json'
 
-# Done
+output = (result) ->
+	# After parsing a file or STDIN, this final step is the only 
+	# runtime difference between cson2json and json2cson
+	process.nextTick ->
+		result = JSON.stringify(result)
+		process.stdout.write(result)
+
+# Parse command line
+cli = new CLI(__PROGRAM_NAME)
+cli.parse()
+cli.run(output)

--- a/src/bin/json2cson.coffee
+++ b/src/bin/json2cson.coffee
@@ -1,19 +1,21 @@
 # Requires
-fs = require('fs')
+util = require('util')
 path = require('path')
+
+CLI = require(path.join __dirname, '..', 'lib', 'cli')
 CSON = require(path.join __dirname, '..', 'lib', 'cson')
-argv = process.argv
 
-# Check arguments
-unless argv.length is 3
-	console.log('usage: json2cson filePath')
-	process.exit(1)
+# Declarations
+__PROGRAM_NAME = 'json2cson'
 
-# Extract
-filePath = argv[2]
-
-# Convert
-result = CSON.stringifySync CSON.parseFileSync(filePath)
-console.log(result)
-
-# Done
+output = (result) ->	
+	# After parsing a file or STDIN, this final step is the only 
+	# runtime difference between cson2json and json2cson
+	process.nextTick ->
+		result = CSON.stringifySync(result)
+		process.stdout.write(result)
+		
+# Parse command line
+cli = new CLI(__PROGRAM_NAME, outputCallback = output)
+cli.parse()
+cli.run(output)

--- a/src/lib/cli.coffee
+++ b/src/lib/cli.coffee
@@ -1,0 +1,118 @@
+# =====================================
+# Requires
+#
+
+# Standard Library
+fs = require('fs')
+path = require('path')
+{EventEmitter} = require('events')
+
+# Third Party
+{docopt,DocoptLanguageError,DocoptExit} = require('docopt')
+
+# Local
+CSON = require(path.join __dirname, '..', 'lib', 'cson')
+
+
+# -------------------------------------
+# Helpers
+#
+
+###
+# Template docstring.
+###
+doc = (__PROGRAM_NAME) ->
+	# (Note: don't use tabs in this string; use 2-space indent)
+	return """
+Usage:
+  #{__PROGRAM_NAME} -
+  #{__PROGRAM_NAME} <file>
+  #{__PROGRAM_NAME} --help
+
+Options:
+  -h, --help  Print this help
+
+
+Use '-' to accept STDIN as input.
+
+"""
+
+
+###
+# Helper. Determines whether to read from STDIN.
+###
+useSTDIN = (parsed_argv) ->
+	return parsed_argv['-']      is true or \
+	       parsed_argv['<file>'] is null
+
+
+###
+# Uses __PROGRAM_NAME to populate help string.
+# Parses command line and returns results.
+###
+parse = (__PROGRAM_NAME) ->
+	name = __PROGRAM_NAME
+	doc = doc(name)
+	return docopt(doc, {name:name, help:true})
+
+
+
+# =====================================
+# Main CLI class
+#
+class CLI extends EventEmitter
+	
+	constructor: (__PROGRAM_NAME) ->
+		@name = __PROGRAM_NAME
+		@_initEvents()
+		@
+	
+	_initEvents: () ->
+		@on 'file', (cb) ->
+			FILE = @parsed_argv['<file>']
+			if fs.existsSync(FILE)
+				result = CSON.parseFileSync(FILE)
+				cb(result)
+			else
+				err = new Error("#{ FILE } does not exist")
+				throw err
+		
+			# Chain
+			@
+		
+		@on 'stdin', (cb) ->
+			data = []
+			process.stdin.setEncoding('utf8')
+			process.stdin
+				.on 'error', (err) ->
+					throw err
+				.on 'readable', ->
+					chunk = process.stdin.read()
+					unless chunk is null
+						data.push(chunk)
+				.on 'end', ->
+					data = data.join ''
+					result = CSON.parseSync(data)
+					cb(result)
+		
+			# Chain
+			@
+		
+		# Chain
+		@
+	
+	parse: () ->
+		@parsed_argv = parse(@name)
+		return @parsed_argv
+	
+	run: (cb) -> 
+		if @useSTDIN(@parsed_argv)
+			@emit('stdin', cb)
+		else
+			@emit('file', cb)
+	
+	useSTDIN: () ->
+		return useSTDIN(@parsed_argv)
+
+# Export CLI
+module.exports = CLI


### PR DESCRIPTION
The tools under `bin/` now accept input from STDIN.  

 * Input can be piped in (`cat file.cson | cson2json -`)
 * Input can be redirected (`cson2json - < file.cson`)

There are a few caveats:

 * **There are no tests for the executables.**
  
  (I tried, but couldn’t.  I’m sure it’s be easy, but I’m continuing to learn Node, and it has a myriad of test frameworks.)

 * **Executables only read from STDIN when passing `-` as the only argument.**

 * **If `-` is passed without actually piping (or redirecting) anything**, the program waits for input until it receives <kbd>CTL</kbd>+<kbd>D</kbd>.

  (I’d like to fix this in the future.  For now, at least it’s consistent with the behavior of `cat - `.  Hitting  will tell the program to stop waiting.)