### PR TITLE
update license

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "version": "3.0.1",
   "description": "CoffeeScript-Object-Notation Parser. Same as JSON but for CoffeeScript objects.",
   "homepage": "https://github.com/bevry/cson",
-  "license": {
-    "type": "MIT"
-  },
+  "license": "MIT",
   "badges": {
     "travis": true,
     "npm": true,


### PR DESCRIPTION
defining license as object is deprecated from npm@2.10

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/